### PR TITLE
Add support for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Windows: https://github.com/MulesGaming/brave-debullshitinator/wiki/Installation
 
 Linux: https://github.com/MulesGaming/brave-debullshitinator/wiki/Installation-instructions#linux
 
+MacOS: https://github.com/MulesGaming/brave-debullshitinator/wiki/Installation-instructions#macos
+
 -------
 
 # Customizing

--- a/brave-debullshitinator-macos-install.sh
+++ b/brave-debullshitinator-macos-install.sh
@@ -1,0 +1,16 @@
+# Start
+echo "Starting Brave debullshitinator installer"
+echo "Brave debullshitinator is made by Mules Gaming. Find it here: https://github.com/MulesGaming/brave-debullshitinator"
+
+defaults write com.brave.Browser BraveRewardsDisabled -boolean true
+defaults write com.brave.Browser BraveWalletDisabled -boolean true
+defaults write com.brave.Browser BraveVPNDisabled -boolean true
+defaults write com.brave.Browser BraveAIChatEnabled -boolean false
+defaults write com.brave.Browser TorDisabled -boolean true
+defaults write com.brave.Browser PasswordManagerEnabled -boolean false
+defaults write com.brave.Browser DnsOverHttpsMode -string "automatic"
+
+# End
+echo "Brave debullshitinator installed"
+
+


### PR DESCRIPTION
Adding support for Mac OS based on https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy

It seem to set policies correctly 
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/a108b8dc-3155-4d55-b782-448e0a15b28d" />

But in my case not everything was removed.

**Removed/disabled:**
* Brave VPN
* Tor
* Brave Password Manager

**Still active**
* Brave Wallet
* Brave Rewards
* Leo AI

**Not sure**
* DNS over HTTPS